### PR TITLE
Min docker

### DIFF
--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -96,7 +96,8 @@ services:
       TESTING_SUPPORT_ENABLED: "${TESTING_SUPPORT_ENABLED:-true}"
       MIGRATIONS_ENDPOINT_ENABLED: "${MIGRATIONS_ENDPOINT_ENABLED:-true}"
       REFERENCE_DATA_API_URL: "${REFERENCE_DATA_API_URL:-http://ccd-test-stubs-service:5555}"
-      ROLE_ASSIGNMENT_URL: "${ROLE_ASSIGNMENT_URL:-http://am-role-assignment-service:4096}"
+      # ROLE_ASSIGNMENT_URL: "${ROLE_ASSIGNMENT_URL:-http://am-role-assignment-service:4096}"
+      ROLE_ASSIGNMENT_URL: "http://${HOST_MACHINE_IP}:4096"
       # Uncomment this line to enable JVM debugging and uncomment the port mapping below
       # JAVA_TOOL_OPTIONS: '-XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0 -XX:MinRAMPercentage=30.0 -XX:+UseConcMarkSweepGC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005'
     ports:
@@ -118,53 +119,53 @@ services:
     networks:
       - ccd-network
 
-  am-role-assignment-service:
-    image: "${AM_ROLE_ASSIGNMENT_SERVICE_USE_LOCAL-hmctspublic.azurecr.io/}am/role-assignment-service:${AM_ROLE_ASSIGNMENT_SERVICE_TAG:-latest}"
-    environment:
-       ROLE_ASSIGNMENT_DB_HOST: ccd-shared-database
-       ROLE_ASSIGNMENT_DB_NAME: role_assignment
-       ROLE_ASSIGNMENT_DB_PORT: 5432
-       ROLE_ASSIGNMENT_DB_USERNAME: "${DB_USERNAME}"
-       ROLE_ASSIGNMENT_DB_PASSWORD: "${DB_PASSWORD}"
-       ROLE_ASSIGNMENT_DB_OPTIONS:
-       AM_ROLE_ASSIGNMENT_SERVICE_SECRET: "${IDAM_KEY_AM_ROLE_ASSIGNMENT}"
-       LD_SDK_KEY:
-       ROLE_ASSIGNMENT_IDAM_KEY:
-       ROLE_ASSIGNMENT_TOKEN_SECRET:
-       ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,wa_task_management_api,xui_webapp,ccd_data,aac_manage_case_assignment,hmc_cft_hearing_service
-       IDAM_USER_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"
-       IDAM_S2S_URL: http://service-auth-provider-api:8080
-       OPEN_ID_API_BASE_URI: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}/o"
-       OIDC_ISSUER_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}/openam/oauth2/hmcts"
-       ROLE_ASSIGNMENT_IDAM_CLIENT_ID: am_role_assignment
-       ROLE_ASSIGNMENT_IDAM_CLIENT_SECRET: am_role_assignment_secret
-       ROLE_ASSIGNMENT_IDAM_ADMIN_USERID: role.assignment.admin@gmail.com
-       ROLE_ASSIGNMENT_IDAM_ADMIN_PASSWORD: "${AM_ROLE_AADMINGMENT_ADMIN_PWD:-Pa55word11}"
-       ROLE_ASSIGNMENT_IDAM_ADMIN_SCOPE: profile openid roles search-user
-       CCD_DATA_STORE_URL: http://ccd-data-store-api:4452
-       AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY:
-       REFORM_SERVICE_NAME: am-role-assignment-service
-       REFORM_TEAM: am
-       REFORM_ENVIRONMENT: local
-       BYPASS_ORG_DROOL_RULE: "true"
-      # Uncomment this line to enable JVM debugging and uncomment the port mapping below
-      #  JAVA_TOOL_OPTIONS: -XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0 -XX:MinRAMPercentage=30.0 -XX:+UseConcMarkSweepGC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-    ports:
-      - 4096:4096
-      # Uncomment this and the JAVA_TOOL_OPTIONS flag for JVM debugging
-      # - 5005:5005
-    depends_on:
-# Uncomment this line to enable ccd test stub service
-#     ccd-test-stubs-service:
-#       condition: service_started
-      idam-api:
-        condition: service_started
-      ccd-shared-database:
-        condition: service_started
-      ccd-data-store-api:
-        condition: service_started
-    networks:
-      - ccd-network
+#   am-role-assignment-service:
+#     image: "${AM_ROLE_ASSIGNMENT_SERVICE_USE_LOCAL-hmctspublic.azurecr.io/}am/role-assignment-service:${AM_ROLE_ASSIGNMENT_SERVICE_TAG:-latest}"
+#     environment:
+#        ROLE_ASSIGNMENT_DB_HOST: ccd-shared-database
+#        ROLE_ASSIGNMENT_DB_NAME: role_assignment
+#        ROLE_ASSIGNMENT_DB_PORT: 5432
+#        ROLE_ASSIGNMENT_DB_USERNAME: "${DB_USERNAME}"
+#        ROLE_ASSIGNMENT_DB_PASSWORD: "${DB_PASSWORD}"
+#        ROLE_ASSIGNMENT_DB_OPTIONS:
+#        AM_ROLE_ASSIGNMENT_SERVICE_SECRET: "${IDAM_KEY_AM_ROLE_ASSIGNMENT}"
+#        LD_SDK_KEY:
+#        ROLE_ASSIGNMENT_IDAM_KEY:
+#        ROLE_ASSIGNMENT_TOKEN_SECRET:
+#        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,wa_task_management_api,xui_webapp,ccd_data,aac_manage_case_assignment,hmc_cft_hearing_service
+#        IDAM_USER_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"
+#        IDAM_S2S_URL: http://service-auth-provider-api:8080
+#        OPEN_ID_API_BASE_URI: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}/o"
+#        OIDC_ISSUER_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}/openam/oauth2/hmcts"
+#        ROLE_ASSIGNMENT_IDAM_CLIENT_ID: am_role_assignment
+#        ROLE_ASSIGNMENT_IDAM_CLIENT_SECRET: am_role_assignment_secret
+#        ROLE_ASSIGNMENT_IDAM_ADMIN_USERID: role.assignment.admin@gmail.com
+#        ROLE_ASSIGNMENT_IDAM_ADMIN_PASSWORD: "${AM_ROLE_AADMINGMENT_ADMIN_PWD:-Pa55word11}"
+#        ROLE_ASSIGNMENT_IDAM_ADMIN_SCOPE: profile openid roles search-user
+#        CCD_DATA_STORE_URL: http://ccd-data-store-api:4452
+#        AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY:
+#        REFORM_SERVICE_NAME: am-role-assignment-service
+#        REFORM_TEAM: am
+#        REFORM_ENVIRONMENT: local
+#        BYPASS_ORG_DROOL_RULE: "true"
+#       # Uncomment this line to enable JVM debugging and uncomment the port mapping below
+#       #  JAVA_TOOL_OPTIONS: -XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0 -XX:MinRAMPercentage=30.0 -XX:+UseConcMarkSweepGC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+#     ports:
+#       - 4096:4096
+#       # Uncomment this and the JAVA_TOOL_OPTIONS flag for JVM debugging
+#       # - 5005:5005
+#     depends_on:
+# # Uncomment this line to enable ccd test stub service
+# #     ccd-test-stubs-service:
+# #       condition: service_started
+#       idam-api:
+#         condition: service_started
+#       ccd-shared-database:
+#         condition: service_started
+#       ccd-data-store-api:
+#         condition: service_started
+#     networks:
+#       - ccd-network
 
   service-auth-provider-api:
     image: "hmctspublic.azurecr.io/rpe/service-auth-provider:latest"

--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -63,63 +63,63 @@ services:
     networks:
       - ccd-network
 
-  ccd-data-store-api:
-    image: "${CCD_DATA_STORE_API_USE_LOCAL-hmctspublic.azurecr.io/}ccd/data-store-api:${CCD_DATA_STORE_API_TAG:-latest}"
-    environment:
-      CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api:4455
-      DATA_STORE_DB_HOST: ccd-shared-database
-      DATA_STORE_DB_PORT: 5432
-      DATA_STORE_DB_USERNAME: "${DB_USERNAME}"
-      DATA_STORE_DB_PASSWORD: "${DB_PASSWORD}"
-      DATA_STORE_DB_USE_SSL: "${DB_USE_SSL}"
-      DATA_STORE_IDAM_KEY: "${IDAM_KEY_CCD_DATA_STORE}"
-      DATA_STORE_TOKEN_SECRET: iuasbcuasdcbasdgcasdgcuysachjsacyasdgjcgasdj
-      DATA_STORE_S2S_AUTHORISED_SERVICES: ccd_gw,ccd_gateway,fpl_case_service,ccd_data,ccd_ps,aac_manage_case_assignment,xui_webapp,ccd_case_document_am_api,am_role_assignment_service,ccd_next_hearing_date_updater,hmc_cft_hearing_service
-      DEFINITION_STORE_HOST: http://ccd-definition-store-api:4451
-      USER_PROFILE_HOST: http://ccd-user-profile-api:4453
-      IDAM_USER_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}" # For backward compatibility with older images
-      IDAM_API_BASE_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"
-      IDAM_OIDC_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"
-      IDAM_S2S_URL: http://service-auth-provider-api:8080
-      IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET: idam_data_store_client_secret
-      REFORM_SERVICE_NAME: ccd-data-store-api
-      REFORM_TEAM: ccd
-      REFORM_ENVIRONMENT: local
-      APPINSIGHTS_INSTRUMENTATIONKEY: key
-      ELASTIC_SEARCH_ENABLED: "${ES_ENABLED_DOCKER}"
-      ELASTIC_SEARCH_HOSTS: ccd-elasticsearch:9200
-      ELASTIC_SEARCH_DATA_NODES_HOSTS: "http://ccd-elasticsearch:9200"
-      CCD_DEFAULTPRINTURL: https://return-case-doc-ccd.nonprod.platform.hmcts.net/jurisdictions/:jid/case-types/:ctid/cases/:cid
-      CCD_DOCUMENT_URL_PATTERN: "${CCD_DOCUMENT_URL_PATTERN}"
-      ENABLE_ATTRIBUTE_BASED_ACCESS_CONTROL: "${ENABLE_ATTRIBUTE_BASED_ACCESS_CONTROL:-true}"
-      ENABLE_PSEUDO_ROLE_ASSIGNMENTS_GENERATION: "${ENABLE_PSEUDO_ROLE_ASSIGNMENTS_GENERATION:-true}"
-      ENABLE_PSEUDO_ACCESS_PROFILES_GENERATION: "${ENABLE_PSEUDO_ACCESS_PROFILES_GENERATION:-true}"
-      TESTING_SUPPORT_ENABLED: "${TESTING_SUPPORT_ENABLED:-true}"
-      MIGRATIONS_ENDPOINT_ENABLED: "${MIGRATIONS_ENDPOINT_ENABLED:-true}"
-      REFERENCE_DATA_API_URL: "${REFERENCE_DATA_API_URL:-http://ccd-test-stubs-service:5555}"
-      # ROLE_ASSIGNMENT_URL: "${ROLE_ASSIGNMENT_URL:-http://am-role-assignment-service:4096}"
-      ROLE_ASSIGNMENT_URL: "http://${HOST_MACHINE_IP}:4096"
-      # Uncomment this line to enable JVM debugging and uncomment the port mapping below
-      # JAVA_TOOL_OPTIONS: '-XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0 -XX:MinRAMPercentage=30.0 -XX:+UseConcMarkSweepGC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005'
-    ports:
-      - 4452:4452
-      # Uncomment this and the JAVA_TOOL_OPTIONS flag for JVM debugging
-      # - 5005:5005
-    depends_on:
-# Uncomment this line to enable ccd test stub service
-#     ccd-test-stubs-service:
-#       condition: service_started
-      idam-api:
-        condition: service_started
-      ccd-shared-database:
-        condition: service_started
-      ccd-user-profile-api:
-        condition: service_started
-      ccd-definition-store-api:
-        condition: service_started
-    restart: always
-    networks:
-      - ccd-network
+#   ccd-data-store-api:
+#     image: "${CCD_DATA_STORE_API_USE_LOCAL-hmctspublic.azurecr.io/}ccd/data-store-api:${CCD_DATA_STORE_API_TAG:-latest}"
+#     environment:
+#       CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api:4455
+#       DATA_STORE_DB_HOST: ccd-shared-database
+#       DATA_STORE_DB_PORT: 5432
+#       DATA_STORE_DB_USERNAME: "${DB_USERNAME}"
+#       DATA_STORE_DB_PASSWORD: "${DB_PASSWORD}"
+#       DATA_STORE_DB_USE_SSL: "${DB_USE_SSL}"
+#       DATA_STORE_IDAM_KEY: "${IDAM_KEY_CCD_DATA_STORE}"
+#       DATA_STORE_TOKEN_SECRET: iuasbcuasdcbasdgcasdgcuysachjsacyasdgjcgasdj
+#       DATA_STORE_S2S_AUTHORISED_SERVICES: ccd_gw,ccd_gateway,fpl_case_service,ccd_data,ccd_ps,aac_manage_case_assignment,xui_webapp,ccd_case_document_am_api,am_role_assignment_service,ccd_next_hearing_date_updater,hmc_cft_hearing_service
+#       DEFINITION_STORE_HOST: http://ccd-definition-store-api:4451
+#       USER_PROFILE_HOST: http://ccd-user-profile-api:4453
+#       IDAM_USER_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}" # For backward compatibility with older images
+#       IDAM_API_BASE_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"
+#       IDAM_OIDC_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"
+#       IDAM_S2S_URL: http://service-auth-provider-api:8080
+#       IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET: idam_data_store_client_secret
+#       REFORM_SERVICE_NAME: ccd-data-store-api
+#       REFORM_TEAM: ccd
+#       REFORM_ENVIRONMENT: local
+#       APPINSIGHTS_INSTRUMENTATIONKEY: key
+#       ELASTIC_SEARCH_ENABLED: "${ES_ENABLED_DOCKER}"
+#       ELASTIC_SEARCH_HOSTS: ccd-elasticsearch:9200
+#       ELASTIC_SEARCH_DATA_NODES_HOSTS: "http://ccd-elasticsearch:9200"
+#       CCD_DEFAULTPRINTURL: https://return-case-doc-ccd.nonprod.platform.hmcts.net/jurisdictions/:jid/case-types/:ctid/cases/:cid
+#       CCD_DOCUMENT_URL_PATTERN: "${CCD_DOCUMENT_URL_PATTERN}"
+#       ENABLE_ATTRIBUTE_BASED_ACCESS_CONTROL: "${ENABLE_ATTRIBUTE_BASED_ACCESS_CONTROL:-true}"
+#       ENABLE_PSEUDO_ROLE_ASSIGNMENTS_GENERATION: "${ENABLE_PSEUDO_ROLE_ASSIGNMENTS_GENERATION:-true}"
+#       ENABLE_PSEUDO_ACCESS_PROFILES_GENERATION: "${ENABLE_PSEUDO_ACCESS_PROFILES_GENERATION:-true}"
+#       TESTING_SUPPORT_ENABLED: "${TESTING_SUPPORT_ENABLED:-true}"
+#       MIGRATIONS_ENDPOINT_ENABLED: "${MIGRATIONS_ENDPOINT_ENABLED:-true}"
+#       REFERENCE_DATA_API_URL: "${REFERENCE_DATA_API_URL:-http://ccd-test-stubs-service:5555}"
+#       # ROLE_ASSIGNMENT_URL: "${ROLE_ASSIGNMENT_URL:-http://am-role-assignment-service:4096}"
+#       ROLE_ASSIGNMENT_URL: "http://${HOST_MACHINE_IP}:4096"
+#       # Uncomment this line to enable JVM debugging and uncomment the port mapping below
+#       # JAVA_TOOL_OPTIONS: '-XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0 -XX:MinRAMPercentage=30.0 -XX:+UseConcMarkSweepGC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005'
+#     ports:
+#       - 4452:4452
+#       # Uncomment this and the JAVA_TOOL_OPTIONS flag for JVM debugging
+#       # - 5005:5005
+#     depends_on:
+# # Uncomment this line to enable ccd test stub service
+# #     ccd-test-stubs-service:
+# #       condition: service_started
+#       idam-api:
+#         condition: service_started
+#       ccd-shared-database:
+#         condition: service_started
+#       ccd-user-profile-api:
+#         condition: service_started
+#       ccd-definition-store-api:
+#         condition: service_started
+#     restart: always
+#     networks:
+#       - ccd-network
 
 #   am-role-assignment-service:
 #     image: "${AM_ROLE_ASSIGNMENT_SERVICE_USE_LOCAL-hmctspublic.azurecr.io/}am/role-assignment-service:${AM_ROLE_ASSIGNMENT_SERVICE_TAG:-latest}"

--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -212,8 +212,8 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - 5050:5432
-    volumes:
-      - ccd-docker-ccd-shared-database-data:/var/lib/postgresql/data
+    # volumes:
+    #   - ccd-docker-ccd-shared-database-data:/var/lib/postgresql/data
     networks:
       - ccd-network
 

--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -59,6 +59,7 @@ services:
         condition: service_started
       ccd-user-profile-api:
         condition: service_started
+    restart: always
     networks:
       - ccd-network
 
@@ -116,6 +117,7 @@ services:
         condition: service_started
       ccd-definition-store-api:
         condition: service_started
+    restart: always
     networks:
       - ccd-network
 

--- a/compose/defaults.conf
+++ b/compose/defaults.conf
@@ -1,7 +1,6 @@
 backend
 frontend
 xui-frontend
-prm
 sidam
 sidam-local
 sidam-local-ccd

--- a/compose/elasticsearch.yml
+++ b/compose/elasticsearch.yml
@@ -3,8 +3,8 @@ services:
   ccd-elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
     container_name: ccd-elasticsearch
-    depends_on:
-      - "ccd-data-store-api"
+    # depends_on:
+    #   - "ccd-data-store-api"
     environment:
       - cluster.name=ccd-docker-es-cluster
       - discovery.type=single-node

--- a/compose/frontend.yml
+++ b/compose/frontend.yml
@@ -58,8 +58,8 @@ services:
       IDAM_OAUTH2_CLIENT_SECRET: ccd_gateway_secret
       IDAM_OAUTH2_TOKEN_ENDPOINT: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}/oauth2/token"
       ADDRESS_LOOKUP_TOKEN:
-      PROXY_AGGREGATED: http://ccd-data-store-api:4452
-      PROXY_DATA: http://ccd-data-store-api:4452
+      PROXY_AGGREGATED: http://${HOST_MACHINE_IP}:4452
+      PROXY_DATA: http://${HOST_MACHINE_IP}:4452
       PROXY_CASE_ACTIVITY: http://host.docker.internal:3460
       PROXY_PRINT_SERVICE: http://host.docker.internal:3200
       PROXY_PAYMENTS: "${PROXY_PAYMENTS_STUB:-http://localhost:9999/payments}"
@@ -72,7 +72,7 @@ services:
     depends_on:
       - ccd-user-profile-api
       - ccd-definition-store-api
-      - ccd-data-store-api
+      # - ccd-data-store-api
     networks:
       - ccd-network
 

--- a/compose/prm.yml
+++ b/compose/prm.yml
@@ -50,51 +50,51 @@ services:
     networks:
       - ccd-network
 
-  am-org-role-mapping-service:
-    image: hmctspublic.azurecr.io/am/org-role-mapping-service:latest
-    container_name: am-org-role-mapping-service
-    environment:
-      IDAM_S2S_URL: http://service-auth-provider-api:8080
-      IDAM_USER_URL: http://idam-api:5000
-      OIDC_ISSUER_URL: http://idam-api:5000/openam/oauth2/hmcts
-      OPEN_ID_API_BASE_URI: "http://idam-api:5000/o"
-      S2S_URL: http://service-auth-provider-api:8080
-      AM_ORG_ROLE_MAPPING_S2S_AUTHORISED_SERVICES: ccd_gw,am_org_role_mapping_service,am_role_assignment_service,xui_webapp,am_role_assignment_refresh_batch
-      ROLE_ASSIGNMENT_APP_URL: http://am-role-assignment-service:4096
-      JUDICIAL_BOOKING_APP_URL: http://am-judicial-booking-service-aat.service.core-compute-aat.internal
-      CASE_WORKER_REF_APP_URL: http://rd-caseworker-ref-api-aat.service.core-compute-aat.internal
-      JUDICIAL_REF_APP_URL: http://rd-judicial-api-aat.service.core-compute-aat.internal
-      JUDICIAL_REF_APP_V2_ACTIVE: "false"
-      JUDICIAL_REF_APP_V2_FILTER_AUTHS_BY_APP_ID: "false"
-      LAUNCH_DARKLY_ENV: aat
-      LD_SDK_KEY: sdk-28c71191-54b1-4d81-8c8d-add52b134bc7
-      AMQP_HOST: rd-servicebus-aat.servicebus.windows.net
-      AMQP_SHARED_ACCESS_KEY_NAME: SendAndListenSharedAccessKey
-      AMQP_ENABLED: "false"
-      TRUST_ALL_CERTS: "true"
-      CRD_TOPIC_NAME: rd-caseworker-topic-aat
-      CRD_SUBSCRIPTION_NAME: rd-caseworker-subscription-aat
-      JRD_TOPIC_NAME: rd-judicial-topic-aat
-      JRD_SUBSCRIPTION_NAME: rd-judicial-subscription-aat
-      ORG_ROLE_MAPPING_IDAM_ADMIN_USERID: orm.admin@hmcts.NET
-      ORG_ROLE_MAPPING_DB_PORT: 5432
-      ORG_ROLE_MAPPING_DB_NAME: org_role_mapping
-      ORG_ROLE_MAPPING_DB_HOST: ccd-shared-database
-      ORG_ROLE_MAPPING_DB_USERNAME: "${DB_USERNAME}"
-      ORG_ROLE_MAPPING_DB_PASSWORD: "${DB_PASSWORD}"
-      ORG_ROLE_MAPPING_DB_OPTIONS: "?stringtype=unspecified"
-      REFRESH_JOB:
-      TESTING_SUPPORT_ENABLED: "true"
-      APPLICATION_LOGGING_LEVEL: INFO
-      RUN_LD_ON_STARTUP: "true"
-    ports:
-      - 4098:4098
-    networks:
-      - ccd-network
-    depends_on:
-      - ccd-shared-database
-    links:
-      - ccd-shared-database
+  # am-org-role-mapping-service:
+  #   image: hmctspublic.azurecr.io/am/org-role-mapping-service:latest
+  #   container_name: am-org-role-mapping-service
+  #   environment:
+  #     IDAM_S2S_URL: http://service-auth-provider-api:8080
+  #     IDAM_USER_URL: http://idam-api:5000
+  #     OIDC_ISSUER_URL: http://idam-api:5000/openam/oauth2/hmcts
+  #     OPEN_ID_API_BASE_URI: "http://idam-api:5000/o"
+  #     S2S_URL: http://service-auth-provider-api:8080
+  #     AM_ORG_ROLE_MAPPING_S2S_AUTHORISED_SERVICES: ccd_gw,am_org_role_mapping_service,am_role_assignment_service,xui_webapp,am_role_assignment_refresh_batch
+  #     ROLE_ASSIGNMENT_APP_URL: http://am-role-assignment-service:4096
+  #     JUDICIAL_BOOKING_APP_URL: http://am-judicial-booking-service-aat.service.core-compute-aat.internal
+  #     CASE_WORKER_REF_APP_URL: http://rd-caseworker-ref-api-aat.service.core-compute-aat.internal
+  #     JUDICIAL_REF_APP_URL: http://rd-judicial-api-aat.service.core-compute-aat.internal
+  #     JUDICIAL_REF_APP_V2_ACTIVE: "false"
+  #     JUDICIAL_REF_APP_V2_FILTER_AUTHS_BY_APP_ID: "false"
+  #     LAUNCH_DARKLY_ENV: aat
+  #     LD_SDK_KEY: sdk-28c71191-54b1-4d81-8c8d-add52b134bc7
+  #     AMQP_HOST: rd-servicebus-aat.servicebus.windows.net
+  #     AMQP_SHARED_ACCESS_KEY_NAME: SendAndListenSharedAccessKey
+  #     AMQP_ENABLED: "false"
+  #     TRUST_ALL_CERTS: "true"
+  #     CRD_TOPIC_NAME: rd-caseworker-topic-aat
+  #     CRD_SUBSCRIPTION_NAME: rd-caseworker-subscription-aat
+  #     JRD_TOPIC_NAME: rd-judicial-topic-aat
+  #     JRD_SUBSCRIPTION_NAME: rd-judicial-subscription-aat
+  #     ORG_ROLE_MAPPING_IDAM_ADMIN_USERID: orm.admin@hmcts.NET
+  #     ORG_ROLE_MAPPING_DB_PORT: 5432
+  #     ORG_ROLE_MAPPING_DB_NAME: org_role_mapping
+  #     ORG_ROLE_MAPPING_DB_HOST: ccd-shared-database
+  #     ORG_ROLE_MAPPING_DB_USERNAME: "${DB_USERNAME}"
+  #     ORG_ROLE_MAPPING_DB_PASSWORD: "${DB_PASSWORD}"
+  #     ORG_ROLE_MAPPING_DB_OPTIONS: "?stringtype=unspecified"
+  #     REFRESH_JOB:
+  #     TESTING_SUPPORT_ENABLED: "true"
+  #     APPLICATION_LOGGING_LEVEL: INFO
+  #     RUN_LD_ON_STARTUP: "true"
+  #   ports:
+  #     - 4098:4098
+  #   networks:
+  #     - ccd-network
+  #   depends_on:
+  #     - ccd-shared-database
+  #   links:
+  #     - ccd-shared-database
 
 networks:
   ccd-network:

--- a/compose/prm.yml
+++ b/compose/prm.yml
@@ -3,52 +3,53 @@ version: '2.4'
 #add non core CCD services here
 
 services:
-  rd-professional-api:
-    image: hmctspublic.azurecr.io/rd/professional-api:latest
-    container_name: rd-professional-api
-    environment:
-      POSTGRES_USERNAME: "${DB_USERNAME}"
-      POSTGRES_PASSWORD: "${DB_PASSWORD}"
-      POSTGRES_HOST: ccd-shared-database
-      POSTGRES_PORT: 5432
-      S2S_URL: http://service-auth-provider-api:8080
-      USER_PROFILE_URL: http://rd-user-profile-api:5602
-      OIDC_ISSUER_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}/openam/oauth2/hmcts"
-      OPEN_ID_API_BASE_URI: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}/o"
-      IDAM_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"
-      CCD_URL: http://ccd-user-profile-api:4453
-      AUTH_IDAM_CLIENT_BASEURL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"
-      LAUNCH_DARKLY_ENV: aat
-    healthcheck:
-      interval: 10s
-      timeout: 10s
-      retries: 10
-    ports:
-      - 5601:8090
-    depends_on:
-      - ccd-shared-database
-    networks:
-      - ccd-network
+  # rd-professional-api:
+  #   image: hmctspublic.azurecr.io/rd/professional-api:latest
+  #   container_name: rd-professional-api
+  #   environment:
+  #     POSTGRES_USERNAME: "${DB_USERNAME}"
+  #     POSTGRES_PASSWORD: "${DB_PASSWORD}"
+  #     POSTGRES_HOST: ccd-shared-database
+  #     POSTGRES_PORT: 5432
+  #     S2S_URL: http://service-auth-provider-api:8080
+  #     # USER_PROFILE_URL: http://rd-user-profile-api:5602
+  #     USER_PROFILE_URL: http://${HOST_MACHINE_IP}:5602
+  #     OIDC_ISSUER_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}/openam/oauth2/hmcts"
+  #     OPEN_ID_API_BASE_URI: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}/o"
+  #     IDAM_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"
+  #     CCD_URL: http://ccd-user-profile-api:4453
+  #     AUTH_IDAM_CLIENT_BASEURL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"
+  #     LAUNCH_DARKLY_ENV: aat
+  #   healthcheck:
+  #     interval: 10s
+  #     timeout: 10s
+  #     retries: 10
+  #   ports:
+  #     - 5601:8090
+  #   depends_on:
+  #     - ccd-shared-database
+  #   networks:
+  #     - ccd-network
 
-  rd-user-profile-api:
-    image: hmctspublic.azurecr.io/rd/user-profile-api:latest
-    container_name: rd-user-profile-api
-    environment:
-      POSTGRES_USERNAME: "${DB_USERNAME}"
-      POSTGRES_PASSWORD: "${DB_PASSWORD}"
-      POSTGRES_HOST: ccd-shared-database
-      POSTGRES_PORT: 5432
-      CCD_URL: http://ccd-user-profile-api:4453
-    healthcheck:
-      interval: 10s
-      timeout: 10s
-      retries: 10
-    ports:
-      - 5602:8090
-    depends_on:
-      - ccd-shared-database
-    networks:
-      - ccd-network
+  # rd-user-profile-api:
+  #   image: hmctspublic.azurecr.io/rd/user-profile-api:latest
+  #   container_name: rd-user-profile-api
+  #   environment:
+  #     POSTGRES_USERNAME: "${DB_USERNAME}"
+  #     POSTGRES_PASSWORD: "${DB_PASSWORD}"
+  #     POSTGRES_HOST: ccd-shared-database
+  #     POSTGRES_PORT: 5432
+  #     CCD_URL: http://ccd-user-profile-api:4453
+  #   healthcheck:
+  #     interval: 10s
+  #     timeout: 10s
+  #     retries: 10
+  #   ports:
+  #     - 5602:8090
+  #   depends_on:
+  #     - ccd-shared-database
+  #   networks:
+  #     - ccd-network
 
   # am-org-role-mapping-service:
   #   image: hmctspublic.azurecr.io/am/org-role-mapping-service:latest

--- a/compose/sidam-local.yml
+++ b/compose/sidam-local.yml
@@ -18,10 +18,10 @@ services:
   shared-db:
     ports:
       - 5432:5432
-  smtp-server:
-    ports:
-      - 1025:1025
-      - 8025:8025
+  # smtp-server:
+  #   ports:
+  #     - 1025:1025
+  #     - 8025:8025
   idam-api:
     ports:
       - 5000:5000

--- a/compose/sidam.yml
+++ b/compose/sidam.yml
@@ -20,8 +20,8 @@ services:
         condition: service_started
   shared-db:
     image: hmctsprivate.azurecr.io/idam/shared-db:latest
-  smtp-server:
-    image: mailhog/mailhog
+  # smtp-server:
+  #   image: mailhog/mailhog
   idam-api:
     image: hmctspublic.azurecr.io/idam/api:stable
     depends_on:

--- a/compose/xui-frontend.yml
+++ b/compose/xui-frontend.yml
@@ -29,7 +29,8 @@ services:
       REDISCLOUD_URL: http://localhost:6780
       SYSTEM_USER_NAME: "dummy"
       SYSTEM_USER_PASSWORD: "dummy"
-      SERVICES_ROLE_ASSIGNMENT_API: http://am-role-assignment-service:4096
+      # SERVICES_ROLE_ASSIGNMENT_API: http://am-role-assignment-service:4096
+      SERVICES_ROLE_ASSIGNMENT_API: http://${HOST_MACHINE_IP}:4096
       SERVICES_PRD_API: http://rd-professional-api:8090
       
       HEALTH_CCD_COMPONENT_API: http://ccd-api-gateway:3453/health

--- a/compose/xui-frontend.yml
+++ b/compose/xui-frontend.yml
@@ -19,7 +19,7 @@ services:
       SERVICES_PAYMENTS_URL: http://wiremock:8080
       SERVICES_EM_ANNO_API: http://ccd-api-gateway:3453
       SERVICES_CCD_COMPONENT_API: http://ccd-api-gateway:3453
-      SERVICES_CCD_DATA_STORE_API: http://ccd-data-store-api:4452
+      SERVICES_CCD_DATA_STORE_API: http://${HOST_MACHINE_IP}:4452
       SERVICES_IDAM_API_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"
       SERVICES_IDAM_CLIENT_ID: "${BEFTA_OAUTH2_CLIENT_ID_OF_XUIWEBAPP:-xuiwebapp}"
       SERVICES_IDAM_LOGIN_URL: "${IDAM_STUB_LOCALHOST:-http://localhost:3501}"
@@ -35,7 +35,7 @@ services:
       SERVICES_PRD_API: http://${HOST_MACHINE_IP}:8090
       
       HEALTH_CCD_COMPONENT_API: http://ccd-api-gateway:3453/health
-      HEALTH_CCD_DATA_API: http://ccd-data-store-api:4452/health
+      HEALTH_CCD_DATA_API: http://${HOST_MACHINE_IP}:4452/health
 
       APPINSIGHTS_INSTRUMENTATIONKEY: TESTVAR
       IDAM_SECRET: "${BEFTA_OAUTH2_CLIENT_SECRET_OF_XUIWEBAPP:-OOOOOOOOOOOOOOOO}"
@@ -46,7 +46,7 @@ services:
       - 3455:3000
     depends_on:
       - ccd-api-gateway
-      - ccd-data-store-api
+      # - ccd-data-store-api
     restart: always
     networks:
       - ccd-network

--- a/compose/xui-frontend.yml
+++ b/compose/xui-frontend.yml
@@ -31,7 +31,8 @@ services:
       SYSTEM_USER_PASSWORD: "dummy"
       # SERVICES_ROLE_ASSIGNMENT_API: http://am-role-assignment-service:4096
       SERVICES_ROLE_ASSIGNMENT_API: http://${HOST_MACHINE_IP}:4096
-      SERVICES_PRD_API: http://rd-professional-api:8090
+      # SERVICES_PRD_API: http://rd-professional-api:8090
+      SERVICES_PRD_API: http://${HOST_MACHINE_IP}:8090
       
       HEALTH_CCD_COMPONENT_API: http://ccd-api-gateway:3453/health
       HEALTH_CCD_DATA_API: http://ccd-data-store-api:4452/health

--- a/compose/xui-frontend.yml
+++ b/compose/xui-frontend.yml
@@ -47,6 +47,7 @@ services:
     depends_on:
       - ccd-api-gateway
       - ccd-data-store-api
+    restart: always
     networks:
       - ccd-network
 


### PR DESCRIPTION
DO NOT MERGE

### Change description ###

To run RAS, RDUP, PRD, CCD in IntelliJ and xui in a Docker container, we need to adjust xui to access the backend APIs running on our host machine. Docker containers have their own network stack, and by default, they can’t directly connect to services running on the host machine using localhost or 127.0.0.1. To find out your host machine IP type:
ifconfig & then search for inet  (include the space) - copy this value

Add the below in your ~/.bash_profile if using bash or ~/.zshenv is using zshell

### for exui to connect to APIs running on your local machine
export HOST_MACHINE_IP=the value from above
### for RAS
export ROLE_ASSIGNMENT_DB_PORT=5050
export ROLE_ASSIGNMENT_DB_NAME=role_assignment
export ROLE_ASSIGNMENT_DB_USERNAME=ccd
export ROLE_ASSIGNMENT_DB_PASSWORD=Pa55word11
export AM_ROLE_ASSIGNMENT_SERVICE_SECRET=AAAAAAAAAAAAAAAA
### for RAS/RDUP/PRD/CCD
export OIDC_ISSUER_URL=http://localhost:5000/openam/oauth2/hmcts
export OPEN_ID_API_BASE_URI=http://localhost:5000/o
### for CCD_DATA_STORE
export DATA_STORE_DB_PORT=5050
export DATA_STORE_S2S_AUTHORISED_SERVICES=ccd_gw,ccd_gateway,fpl_case_service,ccd_data,ccd_ps,aac_manage_case_assignment,xui_webapp,ccd_case_document_am_api,am_role_assignment_service,ccd_next_hearing_date_updater,hmc_cft_hearing_service
### for PRD
export USER_PROFILE_HOST=http://localhost:4453/
### for RDUP
export POSTGRES_PORT=5050
export POSTGRES_USERNAME=ccd
export POSTGRES_PASSWORD=Pa55word11

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
