### PR TITLE
Support persistence of users in IDAM simulator

### DIFF
--- a/compose/prm.yml
+++ b/compose/prm.yml
@@ -19,6 +19,8 @@ services:
       CCD_URL: http://ccd-user-profile-api:4453
       AUTH_IDAM_CLIENT_BASEURL: "${IDAM_STUB_SERVICE_NAME:-http://rse-idam-simulator:5000}"
       LAUNCH_DARKLY_ENV: aat
+      ACCOUNT_NAME: devstoreaccount1 # dummy value
+      ACCOUNT_KEY: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw== # dummy value
     healthcheck:
       interval: 10s
       timeout: 10s

--- a/compose/rse-idam-simulator.yml
+++ b/compose/rse-idam-simulator.yml
@@ -5,6 +5,7 @@ services:
   rse-idam-simulator:
     image: "hmctspublic.azurecr.io/hmcts/rse/rse-idam-simulator:latest"
     container_name: rse-idam-simulator
+    user: root
     ports:
       - "5000:5000"
       # - "5005:5005"
@@ -24,9 +25,16 @@ services:
       SERVER_PORT: 5000
       SIMULATOR_OPENID_BASE_URL: http://rse-idam-simulator:5000
       SIMULATOR_OPENID_BASE_URL_OUTSIDE_NETWORK: http://localhost:5000
+      SIMULATOR_STORAGE_TYPE: persistent
+      SIMULATOR_STORAGE_PERSISTENT_FILE: /opt/app/data/users.db
       # JAVA_TOOL_OPTIONS: -XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0 -XX:MinRAMPercentage=30.0 -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+    volumes:
+      - idam-simulator-data:/opt/app/data
     networks:
       - ccd-network
+
+volumes:
+  idam-simulator-data:
 
 networks:
   ccd-network:


### PR DESCRIPTION
### Change description ###
Enable persistence by default for IDAM simulator, to save need for re-running user script every time containers are brought down and up again.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
